### PR TITLE
Hide the author linkd and logo if not defined for a post

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -31,8 +31,10 @@
             </li>
             {{ end }}
           </ul>
+          {{ if (isset .Params "author") }}
           <span><i class="ti-user mr-2"></i><a
-              href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize }}/">{{ .Params.author }}</a></span>
+              href="{{ `author/` | relLangURL }}{{ .Params.author | urlize }}/">{{ .Params.author }}</a></span>
+          {{ end }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR hides the author icon on single.html (when a single post is viewed) when no author was defined, instead of the icon without a name:
![image](https://user-images.githubusercontent.com/2249071/146760380-103b58b4-bb79-43b1-8d49-aa1fb21d5167.png)
![image](https://user-images.githubusercontent.com/2249071/146760435-ac0aa609-212e-4bdb-8006-1851142f5a3e.png)
![image](https://user-images.githubusercontent.com/2249071/146760468-d1744c3c-2747-4136-8789-6fd25f24c083.png)
