### PR TITLE
Updating Disqus support to fix deprecation error on Hugo v0.120.0+

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,10 +6,7 @@ languageName = "En"
 languageCode = "en-us"
 # post pagination
 paginate = "5"
-# disqus short name
-disqusShortname = "" # get your shortname form here : https://disqus.com# google analytics
 googleAnalytics = "" # example: UA-123-45, for more info, read the article https://support.google.com/analytics/answer/1008080?hl=en
-
 
 ############################# output ##############################
 [outputs]
@@ -88,3 +85,8 @@ preloader = "" # use jpg, png, svg or gif format.
 [params.cookies]
 enable = true
 expire_days = 2
+
+# disqus short name
+[services]
+  [services.disqus]
+    shortname = "" # get your shortname form here : https://disqus.com# google analytics

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -41,7 +41,7 @@
   </div>
 </section>
 
-{{ if .Site.DisqusShortname }}
+{{ if .Site.Config.Services.Disqus.Shortname }}
 <section class="section-sm bg-light">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
# Summary
I use this theme generally within my website https://www.bicyclewatercooler.com and noticed this when setting up a new computer.

I downloaded `brew install hugo` and got:
```
❯ hugo version
hugo v0.138.0+extended+withdeploy darwin/arm64 BuildDate=2024-11-06T11:22:34Z VendorInfo=brew
```
Which meant that when using this theme as a `git submodule`, I suddenly saw my site no longer building with `hugo`:
```
❯ hugo
Start building sites …
hugo v0.138.0+extended+withdeploy darwin/arm64 BuildDate=2024-11-06T11:22:34Z VendorInfo=brew

ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.139.0. Use .Site.Config.Services.Disqus.Shortname instead.
```
So this PR updates the references to Disqus within the theme and its exampleSite configuration.

Note that I don't use Disqus within my project.